### PR TITLE
Add simple React violin tuner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# violine
-detected the GDAE of the violine 
+# Violine
+
+This repository contains a small React tool for hearing the open-string notes of a violin (G, D, A and E). The application uses the Web Audio API to play each note when you click on its button.
+
+## Usage
+
+Open `violin-tuner/index.html` in a modern web browser. Each button will play a sine tone for the corresponding string.

--- a/violin-tuner/index.html
+++ b/violin-tuner/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Violin Tuner</title>
+</head>
+<body>
+  <div id="root"></div>
+
+  <!-- React from CDN -->
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <!-- Babel for JSX transformation -->
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+
+  <script type="text/babel" src="index.js"></script>
+</body>
+</html>

--- a/violin-tuner/index.js
+++ b/violin-tuner/index.js
@@ -1,0 +1,34 @@
+function ViolinTuner() {
+  const notes = [
+    { name: 'G', freq: 196 },
+    { name: 'D', freq: 293.66 },
+    { name: 'A', freq: 440 },
+    { name: 'E', freq: 659.25 },
+  ];
+
+  const playTone = (frequency) => {
+    const AudioContext = window.AudioContext || window.webkitAudioContext;
+    const context = new AudioContext();
+    const oscillator = context.createOscillator();
+    const gainNode = context.createGain();
+    oscillator.type = 'sine';
+    oscillator.frequency.value = frequency;
+    oscillator.connect(gainNode);
+    gainNode.connect(context.destination);
+    oscillator.start();
+    gainNode.gain.exponentialRampToValueAtTime(0.0001, context.currentTime + 2);
+  };
+
+  return (
+    <div>
+      <h1>Violin G-D-A-E Tuner</h1>
+      {notes.map((note) => (
+        <button key={note.name} onClick={() => playTone(note.freq)}>
+          {note.name}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+ReactDOM.render(<ViolinTuner />, document.getElementById('root'));


### PR DESCRIPTION
## Summary
- add a small React-based tuner under `violin-tuner/`
- update README with usage instructions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6851087bd930832d8f2c1426df75cbeb