### PR TITLE
Add mobile version skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ This repository contains a small React tool for hearing the open-string notes of
 ## Usage
 
 Open `violin-tuner/index.html` in a modern web browser. Each button will play a sine tone for the corresponding string.
+
+## Mobile version
+
+The `violin-mobile` folder contains a simple React Native example with a home page, about page, contact page and history page. The app uses `react-navigation` for screen transitions and demonstrates how a mobile version might look.
+

--- a/violin-mobile/App.js
+++ b/violin-mobile/App.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import Header from './components/Header';
+import Footer from './components/Footer';
+import HomeScreen from './screens/HomeScreen';
+import AboutScreen from './screens/AboutScreen';
+import ContactScreen from './screens/ContactScreen';
+import HistoryScreen from './screens/HistoryScreen';
+
+const Stack = createStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Header />
+      <Stack.Navigator initialRouteName="Home">
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="About" component={AboutScreen} />
+        <Stack.Screen name="Contact" component={ContactScreen} />
+        <Stack.Screen name="History" component={HistoryScreen} />
+      </Stack.Navigator>
+      <Footer />
+    </NavigationContainer>
+  );
+}

--- a/violin-mobile/components/Footer.js
+++ b/violin-mobile/components/Footer.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function Footer() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>\u00a9 2023 Violin Tuner</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 10,
+    backgroundColor: '#222',
+  },
+  text: {
+    color: '#aaa',
+    textAlign: 'center',
+  },
+});

--- a/violin-mobile/components/Header.js
+++ b/violin-mobile/components/Header.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function Header() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Violin Tuner</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 20,
+    backgroundColor: '#222',
+  },
+  title: {
+    fontSize: 24,
+    color: '#fff',
+    textAlign: 'center',
+    fontWeight: 'bold',
+  },
+});

--- a/violin-mobile/package.json
+++ b/violin-mobile/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "violin-mobile",
+  "version": "1.0.0",
+  "private": true,
+  "main": "App.js",
+  "dependencies": {
+    "react": "17.0.2",
+    "react-native": "0.66.0",
+    "@react-navigation/native": "^6.1.1",
+    "@react-navigation/stack": "^6.3.1"
+  }
+}

--- a/violin-mobile/screens/AboutScreen.js
+++ b/violin-mobile/screens/AboutScreen.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function AboutScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>About Us</Text>
+      <Text style={styles.paragraph}>
+        We are dedicated to creating simple and effective tools for musicians.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 15,
+  },
+  paragraph: {
+    fontSize: 16,
+    textAlign: 'center',
+  },
+});

--- a/violin-mobile/screens/ContactScreen.js
+++ b/violin-mobile/screens/ContactScreen.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function ContactScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Contact Us</Text>
+      <Text style={styles.paragraph}>Email: info@violintuner.com</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 15,
+  },
+  paragraph: {
+    fontSize: 16,
+  },
+});

--- a/violin-mobile/screens/HistoryScreen.js
+++ b/violin-mobile/screens/HistoryScreen.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function HistoryScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Our History</Text>
+      <Text style={styles.paragraph}>
+        Founded by musicians, our mission is to help violinists stay in tune.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 15,
+  },
+  paragraph: {
+    fontSize: 16,
+    textAlign: 'center',
+  },
+});

--- a/violin-mobile/screens/HomeScreen.js
+++ b/violin-mobile/screens/HomeScreen.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+
+export default function HomeScreen({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Welcome to Violin Tuner</Text>
+      <Button title="About Us" onPress={() => navigation.navigate('About')} />
+      <Button title="Contact" onPress={() => navigation.navigate('Contact')} />
+      <Button title="Our History" onPress={() => navigation.navigate('History')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#f8f8f8',
+  },
+  title: {
+    fontSize: 22,
+    marginBottom: 20,
+  },
+});


### PR DESCRIPTION
## Summary
- add React Native skeleton app with navigation and basic screens
- document the mobile example in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68510d5fe690832d859f4a8d44dc4b26